### PR TITLE
Add iteration over dawg entries

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var binding = require("./lib/jsdawg.node");
 var assert = require("assert");
+var Symbol = require("es6-symbol");
 
 binding.Dawg.prototype.toCompactDawg = function() {
     return new CompactDawg(this.toCompactDawgBuffer());
@@ -48,6 +49,8 @@ CompactDawg.prototype.iterator = function(prefix) {
         }
     }
 }
+
+CompactDawg.prototype[Symbol.iterator] = CompactDawg.prototype.iterator;
 
 module.exports = {
     Dawg: binding.Dawg,

--- a/index.js
+++ b/index.js
@@ -41,12 +41,19 @@ CompactDawg.prototype.lookup = function(prefix) {
 
 CompactDawg.prototype.iterator = function(prefix) {
     // implement the ES6 iterator pattern
-    var it = binding.CompactDawgIterator(this.data);
+    var it = prefix ? new binding.CompactDawgIterator(this.data, prefix) : new binding.CompactDawgIterator(this.data);
     return {
-        next: function() {
-            var n = it.next();
-            return {value: n, done: n === undefined};
-        }
+        next: prefix ?
+            function() {
+                var n = it.next();
+                out = {done: n === undefined};
+                out.value = out.done ? n : prefix + n;
+                return out;
+            } :
+            function() {
+                var n = it.next();
+                return {value: n, done: n === undefined};
+            }
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -38,6 +38,17 @@ CompactDawg.prototype.lookup = function(prefix) {
     return binding.compactDawgBufferLookup(this.data, prefix) == 2;
 }
 
+CompactDawg.prototype.iterator = function(prefix) {
+    // implement the ES6 iterator pattern
+    var it = binding.CompactDawgIterator(this.data);
+    return {
+        next: function() {
+            var n = it.next();
+            return {value: n, done: n === undefined};
+        }
+    }
+}
+
 module.exports = {
     Dawg: binding.Dawg,
     CompactDawg: CompactDawg

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "collections": "^1.2.4",
     "queue-async": "*",
     "request": "*",
-    "tape": "4.2.2"
+    "tape": "4.2.2",
+    "minimist": "1.2.0"
   },
   "scripts": {
     "install": "node-pre-gyp install --fallback-to-build",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "gypfile": true,
   "dependencies": {
     "nan": "*",
-    "node-pre-gyp": "0.5.x"
+    "node-pre-gyp": "0.5.x",
+    "es6-symbol": "3.0.2",
+    "es6-iterator": "2.0.0"
   },
   "devDependencies": {
     "collections": "^1.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dawg-cache",
-  "version": "0.2.0",
+  "version": "0.2.0-prefix",
   "description": "Javascript/C++ DAWG implementation",
   "main": "index.js",
   "private": false,

--- a/scripts/dawg-create.js
+++ b/scripts/dawg-create.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+var jsdawg = require("../index");
+var readline = require("readline");
+var minimist = require("minimist");
+var fs = require("fs");
+
+var argv = require('minimist')(process.argv.slice(2));
+
+var input = (argv._.length == 0 || argv._[0] == "-") ? process.stdin : fs.createReadStream(argv._[0]);
+var output = (argv._.length < 2 || argv._[1] == "-") ? process.stdout : fs.createWriteStream(argv._[1]);
+
+var dawg = new jsdawg.Dawg();
+
+var rl = readline.createInterface({
+    input: input,
+    output: process.stdout,
+    terminal: false
+});
+
+rl.on('line', function(line) {
+    line = line.trim();
+    if (line.length) {
+        dawg.insert(line);
+    }
+});
+
+rl.on('close', function() {
+    dawg.finish();
+    output.write(dawg.toCompactDawgBuffer());
+});

--- a/scripts/dawg-dump.js
+++ b/scripts/dawg-dump.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+var jsdawg = require("../index");
+var minimist = require("minimist");
+var fs = require("fs");
+var forOf = require("es6-iterator/for-of");
+
+var argv = require('minimist')(process.argv.slice(2));
+
+var input = (argv._.length == 0 || argv._[0] == "-") ? process.stdin : fs.createReadStream(argv._[0]);
+var output = (argv._.length < 2 || argv._[1] == "-") ? process.stdout : fs.createWriteStream(argv._[1]);
+
+var chunks = [];
+input.on('data', function(chunk) { chunks.push(chunk); });
+input.on('end', function() {
+    var data = Buffer.concat(chunks);
+    var compactDawg = new jsdawg.CompactDawg(data);
+    forOf(compactDawg, function(value) {
+        console.log(value);
+    })
+});

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -124,20 +124,19 @@ class JSDawg : public Nan::ObjectWrap {
     }
 };
 
-NAN_METHOD(CompactLookup) {
-    v8::Local<v8::Object> bufferObj = info[0]->ToObject();
-    String::Utf8Value utf8_value(info[1].As<String>());
+typedef struct {
+    int node_offset;
+    bool found;
+    bool final;
+} dawg_search_result;
 
-    unsigned char* search = (unsigned char*) *utf8_value;
-    size_t search_length = utf8_value.length();
-
-    unsigned char* full_data = (unsigned char*) node::Buffer::Data(bufferObj);
-    unsigned char* data = full_data + DAWG_HEADER_SIZE;
-
+dawg_search_result compact_dawg_search(unsigned char* data, unsigned char* search, size_t search_length) {
     unsigned int flagged_offset, node_final = 0;
     int node_offset = 0, edge_count, edge_offset, min, max, guess;
     bool match = false;
     char search_letter, letter;
+
+    dawg_search_result output;
 
     for (size_t i = 0; i < search_length; i++) {
         // binary search over the node edges
@@ -175,13 +174,38 @@ NAN_METHOD(CompactLookup) {
 
             if (node_offset == 0) node_offset = -1;
         } else {
-            info.GetReturnValue().Set(0);
-            return;
+            output.node_offset = -1;
+            output.found = false;
+            output.final = false;
+            return output;
         }
     }
 
-    info.GetReturnValue().Set(node_final ? 2 : 1);
-    return;
+    output.node_offset = node_offset;
+    output.found = true;
+    output.final = node_final;
+    return output;
+}
+
+NAN_METHOD(CompactLookup) {
+    v8::Local<v8::Object> bufferObj = info[0]->ToObject();
+    String::Utf8Value utf8_value(info[1].As<String>());
+
+    unsigned char* search = (unsigned char*) *utf8_value;
+    size_t search_length = utf8_value.length();
+
+    unsigned char* full_data = (unsigned char*) node::Buffer::Data(bufferObj);
+    unsigned char* data = full_data + DAWG_HEADER_SIZE;
+
+    dawg_search_result result = compact_dawg_search(data, search, search_length);
+
+    if (result.found) {
+        info.GetReturnValue().Set(result.final ? 2 : 1);
+        return;
+    } else {
+        info.GetReturnValue().Set(0);
+        return;
+    }
 }
 
 class CompactIterator : public Nan::ObjectWrap {
@@ -207,10 +231,11 @@ class CompactIterator : public Nan::ObjectWrap {
         unsigned char* data;
         std::vector<node_position>* stack;
         std::vector<unsigned char>* current_word;
+        bool return_empty;
 
     static NAN_METHOD(New) {
         if (info.IsConstructCall()) {
-            if (info.Length() != 1) {
+            if (info.Length() != 1 && info.Length() != 2) {
                 Nan::ThrowTypeError("Invalid number of arguments");
                 return;
             }
@@ -233,24 +258,52 @@ class CompactIterator : public Nan::ObjectWrap {
             obj->data = full_data + DAWG_HEADER_SIZE;
             obj->current_word = new std::vector<unsigned char>();
             obj->stack = new std::vector<node_position>();
+            obj->return_empty = false;
 
-            // enqueue the root
             node_position current_position;
-            current_position.node_offset = 0;
-            current_position.edge_idx = 0;
-            current_position.visited = false;
+            if (info.Length() == 2) {
+                // we're doing a prefix search, so find the prefix node and
+                // enqueue it if it exists
+                String::Utf8Value utf8_value(info[1].As<String>());
 
-            obj->stack->push_back(current_position);
+                unsigned char* search = (unsigned char*) *utf8_value;
+                size_t search_length = utf8_value.length();
+
+                dawg_search_result result = compact_dawg_search(obj->data, search, search_length);
+
+                if (result.found) {
+                    if (result.final) {
+                        obj->return_empty = true;
+                    }
+                    if (result.node_offset != -1) {
+                        current_position.node_offset = result.node_offset;
+                        current_position.edge_idx = 0;
+                        current_position.visited = false;
+
+                        obj->stack->push_back(current_position);
+                    }
+                }
+            } else {
+                // enqueue the root
+                current_position.node_offset = 0;
+                current_position.edge_idx = 0;
+                current_position.visited = false;
+
+                obj->stack->push_back(current_position);
+            }
         } else {
-            const int argc = 1;
-            v8::Local<v8::Value> argv[argc] = {info[0]};
-            v8::Local<v8::Function> cons = Nan::New(constructor());
-            info.GetReturnValue().Set(Nan::NewInstance(cons, argc, argv).ToLocalChecked());
+            Nan::ThrowTypeError("CompactDawgIterator needs to be called as a constructor");
         }
     }
 
     static NAN_METHOD(Next) {
         CompactIterator* obj = Nan::ObjectWrap::Unwrap<CompactIterator>(info.This());
+
+        if (obj->return_empty) {
+            obj->return_empty = false;
+            info.GetReturnValue().Set(Nan::New("").ToLocalChecked());
+            return;
+        }
 
         unsigned char* data = obj->data;
         std::vector<node_position>* stack = obj->stack;

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -259,9 +259,6 @@ class CompactIterator : public Nan::ObjectWrap {
         bool has_output = false;
 
         while (stack->size() > 0 && !has_output) {
-            // if the stack is empty, we're done
-            if (!stack->size()) break;
-
             current_position = stack->back();
 
             edge_offset = current_position.node_offset + 1 + (5 * current_position.edge_idx);
@@ -279,10 +276,12 @@ class CompactIterator : public Nan::ObjectWrap {
             if (next_offset == 0 || current_position.visited) {
                 stack->pop_back();
 
-                new_back = stack->back();
-                new_back.visited = true;
-                stack->pop_back();
-                stack->push_back(new_back);
+                if (stack->size() > 0) {
+                    new_back = stack->back();
+                    new_back.visited = true;
+                    stack->pop_back();
+                    stack->push_back(new_back);
+                }
 
                 edge_count = (int) data[current_position.node_offset];
                 if (current_position.edge_idx < edge_count - 1) {

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -229,8 +229,8 @@ class CompactIterator : public Nan::ObjectWrap {
         ~CompactIterator() { persistentBuffer.Reset(); }
         Nan::Persistent<v8::Object> persistentBuffer;
         unsigned char* data;
-        std::vector<node_position>* stack;
-        std::vector<unsigned char>* current_word;
+        std::vector<node_position> stack;
+        std::vector<unsigned char> current_word;
         bool return_empty;
 
     static NAN_METHOD(New) {
@@ -256,8 +256,6 @@ class CompactIterator : public Nan::ObjectWrap {
 
             unsigned char* full_data = (unsigned char*) node::Buffer::Data(bufferObj);
             obj->data = full_data + DAWG_HEADER_SIZE;
-            obj->current_word = new std::vector<unsigned char>();
-            obj->stack = new std::vector<node_position>();
             obj->return_empty = false;
 
             node_position current_position;
@@ -280,7 +278,7 @@ class CompactIterator : public Nan::ObjectWrap {
                         current_position.edge_idx = 0;
                         current_position.visited = false;
 
-                        obj->stack->push_back(current_position);
+                        obj->stack.push_back(current_position);
                     }
                 }
             } else {
@@ -289,7 +287,7 @@ class CompactIterator : public Nan::ObjectWrap {
                 current_position.edge_idx = 0;
                 current_position.visited = false;
 
-                obj->stack->push_back(current_position);
+                obj->stack.push_back(current_position);
             }
         } else {
             Nan::ThrowTypeError("CompactDawgIterator needs to be called as a constructor");
@@ -306,8 +304,8 @@ class CompactIterator : public Nan::ObjectWrap {
         }
 
         unsigned char* data = obj->data;
-        std::vector<node_position>* stack = obj->stack;
-        std::vector<unsigned char>* current_word = obj->current_word;
+        std::vector<node_position>* stack = &(obj->stack);
+        std::vector<unsigned char>* current_word = &(obj->current_word);
 
         unsigned int flagged_offset, next_final = 0;
         unsigned int next_offset = 0, edge_count, edge_offset;

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -271,7 +271,7 @@ class CompactIterator : public Nan::ObjectWrap {
             next_offset = (int)(flagged_offset & FINAL_MASK);
             next_final = flagged_offset & IS_FINAL_FLAG;
 
-            if (next_final) {
+            if (next_final && !current_position.visited) {
                 has_output = true;
                 output = std::string(current_word->begin(), current_word->end()) + letter;
             }

--- a/test/dawg.test.js
+++ b/test/dawg.test.js
@@ -109,6 +109,35 @@ test('DAWG test', function (t) {
         }
         t.assert(iteratorLookup, "compact dawg iterator reproduces original list");
 
+        var prefixWords = [];
+        var prefixIterator = compactDawg.iterator("test");
+        var priNext = prefixIterator.next();
+        while (!priNext.done) {
+            prefixWords.push(priNext.value);
+            priNext = prefixIterator.next();
+        }
+        t.assert(prefixWords.length == 82, "got 82 results for prefix 'test'");
+        t.assert(prefixWords.indexOf("test") == 0, "submitted prefix 'test' is included in results");
+
+        var prefixWords = [];
+        var prefixIterator = compactDawg.iterator("testac");
+        var priNext = prefixIterator.next();
+        while (!priNext.done) {
+            prefixWords.push(priNext.value);
+            priNext = prefixIterator.next();
+        }
+        t.assert(prefixWords.length == 7, "got 7 results for prefix 'testac'");
+        t.assert(prefixWords.indexOf("testac") == -1, "submitted prefix 'testac' is not included in results");
+
+        var prefixWords = [];
+        var prefixIterator = compactDawg.iterator("testaaa");
+        var priNext = prefixIterator.next();
+        while (!priNext.done) {
+            prefixWords.push(priNext.value);
+            priNext = prefixIterator.next();
+        }
+        t.assert(prefixWords.length == 0, "got 0 results for prefix 'testaaa'");
+
         var lookupFailure = true;
         for (var i = 0; i < words.length; i++) {
             lookupFailure = lookupFailure && (!compactDawg.lookup(words[i]) + "q");

--- a/test/dawg.test.js
+++ b/test/dawg.test.js
@@ -2,6 +2,7 @@ var test = require('tape');
 var request = require('request');
 var queue = require('queue-async');
 var zlib = require('zlib');
+var forOf = require('es6-iterator/for-of');
 require('collections/collections.js');
 
 var jsdawg = require("../index");
@@ -98,6 +99,14 @@ test('DAWG test', function (t) {
             prefixLookup = prefixLookup && compactDawg.lookupPrefix(prefix);
         }
         t.assert(prefixLookup, "compact dawg contains prefixes of all words as prefixes");
+
+        var compactDawgWords = [];
+        forOf(compactDawg, function(value) { compactDawgWords.push(value); });
+        var iteratorLookup = true;
+        for (var i = 0; i < words.length; i++) {
+            iteratorLookup = iteratorLookup && (words[i] == compactDawgWords[i]);
+        }
+        t.assert(iteratorLookup, "compact dawg iterator reproduces original list");
 
         var lookupFailure = true;
         for (var i = 0; i < words.length; i++) {


### PR DESCRIPTION
Add a mechanism for iterating over the contents of a dawg cache, with two variants/use cases:
- iterate over all strings, for use in merging
- iterate over all strings that start with a given prefix, for use in grid cache optimization
