### PR TITLE
Add ability to build in debug mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,17 +15,21 @@ matrix:
      # Linux
      - os: linux
        compiler: clang
-       env: NODE_VERSION="0.10.38" # node abi 11
+       env: NODE_VERSION="0.10.38" PUBLISHABLE=true
      - os: linux
        compiler: clang
-       env: NODE_VERSION="4.4.2" # node abi 46
+       env: NODE_VERSION="4.4.2" PUBLISHABLE=true
+     # Debug build (only for testing)
+     - os: linux
+       compiler: clang
+       env: NODE_VERSION="4.4.2" NPM_FLAGS="--debug"
      # OS X
      - os: osx
        compiler: clang
-       env: NODE_VERSION="0.10.38" # node abi 11
+       env: NODE_VERSION="0.10.38" PUBLISHABLE=true
      - os: osx
        compiler: clang
-       env: NODE_VERSION="4.4.2" # node abi 46
+       env: NODE_VERSION="4.4.2" PUBLISHABLE=true
 
 env:
   global:
@@ -43,10 +47,10 @@ before_install:
   - nvm use $NODE_VERSION
 
 install:
-  - npm install --build-from-source --clang=1
+  - npm install --build-from-source --clang=1 ${NPM_FLAGS:-}
 
 script:
   - npm test
 
 after_success:
-  - ./test/travis-publish.sh
+  - if [[ ${PUBLISHABLE:-} == true ]]; then ./test/travis-publish.sh; fi

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,25 +1,28 @@
 {
+  'includes': [ 'common.gypi' ],
   "targets": [
     {
       "target_name": "jsdawg",
       "sources": [
         "src/binding.cpp"
       ],
-      "include_dirs"  : [
-            "<!(node -e \"require('nan')\")"
+      'include_dirs': [
+        '<!(node -e \'require("nan")\')'
       ],
-      "cflags": ["-std=c++11", "-O3"],
-      'cflags_cc!': ['-Os'],
-      'conditions': [
-        ['OS=="mac"', {
-          'xcode_settings': {
-            'OTHER_CFLAGS': ['-O3'],
-            'OTHER_CPLUSPLUSFLAGS' : ['-std=c++11','-stdlib=libc++', '-O3'],
-            'OTHER_LDFLAGS': ['-stdlib=libc++'],
-            'MACOSX_DEPLOYMENT_TARGET': '10.7'
-          }
-        }]
-      ]
+      'ldflags': [
+        '-Wl,-z,now',
+      ],
+      'xcode_settings': {
+        'OTHER_LDFLAGS':[
+          '-Wl,-bind_at_load'
+        ],
+        'GCC_ENABLE_CPP_RTTI': 'YES',
+        'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+        'MACOSX_DEPLOYMENT_TARGET':'10.8',
+        'CLANG_CXX_LIBRARY': 'libc++',
+        'CLANG_CXX_LANGUAGE_STANDARD':'c++11',
+        'GCC_VERSION': 'com.apple.compilers.llvm.clang.1_0'
+      }
     },
     {
       "target_name": "action_after_build",

--- a/common.gypi
+++ b/common.gypi
@@ -1,0 +1,45 @@
+{
+  'target_defaults': {
+    'default_configuration': 'Release',
+    'cflags_cc' : [
+      '-std=c++11',
+    ],
+    'cflags_cc!': ['-std=gnu++0x','-fno-rtti', '-fno-exceptions'],
+    'configurations': {
+      'Debug': {
+        'defines!': [
+          'NDEBUG'
+        ],
+        'cflags_cc!': [
+          '-O3',
+          '-Os',
+          '-DNDEBUG'
+        ],
+        'xcode_settings': {
+          'OTHER_CPLUSPLUSFLAGS!': [
+            '-O3',
+            '-Os',
+            '-DDEBUG'
+          ],
+          'GCC_OPTIMIZATION_LEVEL': '0',
+          'GCC_GENERATE_DEBUGGING_SYMBOLS': 'YES'
+        }
+      },
+      'Release': {
+        'defines': [
+          'NDEBUG'
+        ],
+        'xcode_settings': {
+          'OTHER_CPLUSPLUSFLAGS!': [
+            '-Os',
+            '-O2'
+          ],
+          'GCC_OPTIMIZATION_LEVEL': '3',
+          'GCC_GENERATE_DEBUGGING_SYMBOLS': 'NO',
+          'DEAD_CODE_STRIPPING': 'YES',
+          'GCC_INLINES_ARE_PRIVATE_EXTERN': 'YES'
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds testing of Debug builds to travis. The motivation here is:

  - Sometimes debug builds abort on invalid usage
  - We should start adding aborts on invalid data / invalid bounds checking to the cpp code (so tests catch this, but there is no runtime performance cost)
  - Debug builds might be beneficial to publish in the future for debugging potential crashes (better backtraces from https://github.com/mapbox/logbt/)