### PR TITLE
Various optimizations

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -60,6 +60,9 @@ class JSDawg : public Nan::ObjectWrap {
     }
 
     static NAN_METHOD(Insert) {
+        if (!info[0]->IsString()) {
+            return Nan::ThrowTypeError("first argument must be a String");
+        }
         JSDawg* obj = Nan::ObjectWrap::Unwrap<JSDawg>(info.This());
         String::Utf8Value utf8_value(info[0].As<String>());
         std::string input = std::string(*utf8_value, utf8_value.length());
@@ -76,6 +79,9 @@ class JSDawg : public Nan::ObjectWrap {
     }
 
     static NAN_METHOD(Lookup) {
+        if (!info[0]->IsString()) {
+            return Nan::ThrowTypeError("first argument must be a String");
+        }
         JSDawg* obj = Nan::ObjectWrap::Unwrap<JSDawg>(info.This());
         String::Utf8Value utf8_value(info[0].As<String>());
         std::string input = std::string(*utf8_value, utf8_value.length());
@@ -85,6 +91,9 @@ class JSDawg : public Nan::ObjectWrap {
     }
 
     static NAN_METHOD(LookupPrefix) {
+        if (!info[0]->IsString()) {
+            return Nan::ThrowTypeError("first argument must be a String");
+        }
         JSDawg* obj = Nan::ObjectWrap::Unwrap<JSDawg>(info.This());
         String::Utf8Value utf8_value(info[0].As<String>());
         std::string input = std::string(*utf8_value, utf8_value.length());
@@ -188,7 +197,19 @@ dawg_search_result compact_dawg_search(unsigned char* data, unsigned char* searc
 }
 
 NAN_METHOD(CompactLookup) {
+    if (!info[0]->IsObject()) {
+        return Nan::ThrowTypeError("first argument must be a Buffer");
+    }
+
     v8::Local<v8::Object> bufferObj = info[0]->ToObject();
+
+    if (bufferObj->IsNull() || bufferObj->IsUndefined() || !node::Buffer::HasInstance(bufferObj)) {
+        return Nan::ThrowTypeError("first argument must be a Buffer");
+    }
+
+    if (!info[1]->IsString()) {
+        return Nan::ThrowTypeError("second argument must be a String");
+    }
     String::Utf8Value utf8_value(info[1].As<String>());
 
     unsigned char* search = (unsigned char*) *utf8_value;
@@ -398,16 +419,8 @@ NAN_METHOD(Crc32c) {
 static NAN_MODULE_INIT(Init) {
     JSDawg::Init(target);
     CompactIterator::Init(target);
-    Nan::Set(
-        target,
-        Nan::New("compactDawgBufferLookup").ToLocalChecked(),
-        Nan::GetFunction(New<FunctionTemplate>(CompactLookup)).ToLocalChecked()
-    );
-    Nan::Set(
-        target,
-        Nan::New("crc32c").ToLocalChecked(),
-        Nan::GetFunction(New<FunctionTemplate>(Crc32c)).ToLocalChecked()
-    );
+    Nan::SetMethod(target,"compactDawgBufferLookup",CompactLookup);
+    Nan::SetMethod(target,"crc32c",Crc32c);
 }
 
 NODE_MODULE(jsdawg, Init)

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -87,9 +87,7 @@ class JSDawg : public Nan::ObjectWrap {
         }
         JSDawg* obj = Nan::ObjectWrap::Unwrap<JSDawg>(info.This());
         String::Utf8Value utf8_value(info[0].As<String>());
-        std::string input = std::string(*utf8_value, utf8_value.length());
-        bool found = obj->dawg_.lookup(input);
-
+        bool found = obj->dawg_.lookup(*utf8_value, utf8_value.length());
         info.GetReturnValue().Set(found);
     }
 
@@ -99,8 +97,7 @@ class JSDawg : public Nan::ObjectWrap {
         }
         JSDawg* obj = Nan::ObjectWrap::Unwrap<JSDawg>(info.This());
         String::Utf8Value utf8_value(info[0].As<String>());
-        std::string input = std::string(*utf8_value, utf8_value.length());
-        bool found = obj->dawg_.lookup_prefix(input);
+        bool found = obj->dawg_.lookup_prefix(*utf8_value, utf8_value.length());
 
         info.GetReturnValue().Set(found);
     }

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -197,19 +197,9 @@ dawg_search_result compact_dawg_search(unsigned char* data, unsigned char* searc
 }
 
 NAN_METHOD(CompactLookup) {
-    if (!info[0]->IsObject()) {
-        return Nan::ThrowTypeError("first argument must be a Buffer");
-    }
-
+    // NOTE: these values are not validated since this
+    // function is wrapped in JS
     v8::Local<v8::Object> bufferObj = info[0]->ToObject();
-
-    if (!node::Buffer::HasInstance(bufferObj)) {
-        return Nan::ThrowTypeError("first argument must be a Buffer");
-    }
-
-    if (!info[1]->IsString()) {
-        return Nan::ThrowTypeError("second argument must be a String");
-    }
     String::Utf8Value utf8_value(info[1].As<String>());
 
     unsigned char* search = (unsigned char*) *utf8_value;

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -63,13 +63,16 @@ class JSDawg : public Nan::ObjectWrap {
         if (!info[0]->IsString()) {
             return Nan::ThrowTypeError("first argument must be a String");
         }
-        JSDawg* obj = Nan::ObjectWrap::Unwrap<JSDawg>(info.This());
         String::Utf8Value utf8_value(info[0].As<String>());
-        std::string input = std::string(*utf8_value, utf8_value.length());
-        bool success = obj->dawg_.insert(input);
-
-        if (!success) {
-            Nan::ThrowError("Entries must be inserted in order");
+        int len = utf8_value.length();
+        if (len <= 0) {
+            Nan::ThrowError("empty string passed to insert");
+        } else {
+            JSDawg* obj = Nan::ObjectWrap::Unwrap<JSDawg>(info.This());
+            bool success = obj->dawg_.insert(*utf8_value, static_cast<std::size_t>(len));
+            if (!success) {
+                Nan::ThrowError("Entries must be inserted in order");
+            }
         }
     }
 

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -205,28 +205,112 @@ dawg_search_result compact_dawg_search(unsigned char* data, unsigned char* searc
     return output;
 }
 
-NAN_METHOD(CompactLookup) {
-    // NOTE: these values are not validated since this
-    // function is wrapped in JS
-    v8::Local<v8::Object> bufferObj = info[0]->ToObject();
-    String::Utf8Value utf8_value(info[1].As<String>());
+constexpr std::size_t arena_size = 1024;
 
-    unsigned char* search = (unsigned char*) *utf8_value;
-    size_t search_length = utf8_value.length();
+class CompactDawg : public Nan::ObjectWrap {
+    public:
+        static void Init(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
+            v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
+            tpl->SetClassName(Nan::New("CompactDawg").ToLocalChecked());
+            tpl->InstanceTemplate()->SetInternalFieldCount(1);
+            SetPrototypeMethod(tpl, "_lookup", Lookup);
+            constructor().Reset(Nan::GetFunction(tpl).ToLocalChecked());
+            Nan::Set(
+                target,
+                Nan::New("CompactDawg").ToLocalChecked(),
+                Nan::GetFunction(tpl).ToLocalChecked()
+            );
+        }
+    private:
+        explicit CompactDawg(v8::Local<v8::Object> buf)
+          : data(node::Buffer::Data(buf) + DAWG_HEADER_SIZE),
+            len(node::Buffer::Length(buf)),
+            persistentBuffer() {
+              persistentBuffer.Reset(buf);
+          }
+        ~CompactDawg() { persistentBuffer.Reset(); }
+        char* data;
+        size_t len;
+        Nan::Persistent<v8::Object> persistentBuffer;
 
-    unsigned char* full_data = (unsigned char*) node::Buffer::Data(bufferObj);
-    unsigned char* data = full_data + DAWG_HEADER_SIZE;
+    static NAN_METHOD(New) {
+        if (info.IsConstructCall()) {
+            if (info.Length() != 1) {
+                Nan::ThrowTypeError("Invalid number of arguments");
+                return;
+            }
 
-    dawg_search_result result = compact_dawg_search(data, search, search_length);
+            v8::Local<v8::Value> obj = info[0];
+            if (!obj->IsObject()) {
+                return Nan::ThrowTypeError("first argument must be a Buffer");
+            }
 
-    if (result.found) {
-        info.GetReturnValue().Set(result.final ? 2 : 1);
-        return;
-    } else {
-        info.GetReturnValue().Set(0);
-        return;
+            if (!node::Buffer::HasInstance(obj)) {
+                Nan::ThrowTypeError("Input must be a buffer");
+                return;
+            }
+
+            CompactDawg *dawg = new CompactDawg(obj->ToObject());
+            dawg->Wrap(info.This());
+            info.GetReturnValue().Set(info.This());
+        } else {
+            Nan::ThrowTypeError("CompactDawg needs to be called as a constructor");
+        }
     }
-}
+
+    static NAN_METHOD(Lookup) {
+        CompactDawg* obj = Nan::ObjectWrap::Unwrap<CompactDawg>(info.This());
+        v8::Local<v8::Value> js_val = info[0];
+        std::uint32_t return_val = 1;
+        // https://github.com/nodejs/node/commit/44a40325da4031f5a5470bec7b07fb8be5f9e99e
+        // https://github.com/nodejs/node/pull/1042
+        if (!js_val.IsEmpty()) {
+            v8::Local<v8::String> js_str = js_val->ToString();
+            if (!js_str.IsEmpty()) {
+                int js_str_len = js_str->Length();
+                if (js_str_len > 0) {
+                    // Also passing v8::String::HINT_MANY_WRITES_EXPECTED flattens string
+                    // but I've not enabled this yet as it does not clearly increase performance
+                    const int flags =
+                        v8::String::NO_NULL_TERMINATION | v8::String::REPLACE_INVALID_UTF8;
+                    // max possible decoded utf length
+                    // much faster than calling `str->Utf8Length();` to get exact length
+                    // https://github.com/nodejs/node/blob/bfd3c7e626306cc5793618da2b56d37df338eb05/src/string_bytes.cc#L392
+                    std::size_t len = (3 * js_str_len) + 1;
+                    if (len > arena_size) {
+                        char * heap_string = static_cast<char *>(std::malloc(len));
+                        std::size_t utf8_length = js_str->WriteUtf8(heap_string, static_cast<int>(len), 0, flags);
+                        heap_string[utf8_length] = '\0';
+                        dawg_search_result result = compact_dawg_search((unsigned char*)obj->data, (unsigned char*)heap_string, utf8_length);
+                        if (result.found) {
+                            return_val = result.final ? 2 : 1;
+                        } else {
+                            return_val = 0;
+                        }
+                        free(heap_string);
+                    } else {
+                        char arena[arena_size];
+                        std::size_t utf8_length = js_str->WriteUtf8(arena, static_cast<int>(len), 0, flags);
+                        arena[utf8_length] = '\0';
+                        dawg_search_result result = compact_dawg_search((unsigned char*)obj->data, (unsigned char*)arena, utf8_length);
+                        if (result.found) {
+                            return_val = result.final ? 2 : 1;
+                        } else {
+                            return_val = 0;
+                        }
+                    }
+                }
+            }
+        }
+        info.GetReturnValue().Set(return_val);
+        return;
+        }
+
+    static inline Nan::Persistent<v8::Function> & constructor() {
+        static Nan::Persistent<v8::Function> my_constructor;
+        return my_constructor;
+    }
+};
 
 class CompactIterator : public Nan::ObjectWrap {
     public:
@@ -409,8 +493,8 @@ NAN_METHOD(Crc32c) {
 
 static NAN_MODULE_INIT(Init) {
     JSDawg::Init(target);
+    CompactDawg::Init(target);
     CompactIterator::Init(target);
-    Nan::SetMethod(target,"compactDawgBufferLookup",CompactLookup);
     Nan::SetMethod(target,"crc32c",Crc32c);
 }
 

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -203,7 +203,7 @@ NAN_METHOD(CompactLookup) {
 
     v8::Local<v8::Object> bufferObj = info[0]->ToObject();
 
-    if (bufferObj->IsNull() || bufferObj->IsUndefined() || !node::Buffer::HasInstance(bufferObj)) {
+    if (!node::Buffer::HasInstance(bufferObj)) {
         return Nan::ThrowTypeError("first argument must be a Buffer");
     }
 

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -131,12 +131,12 @@ bool build_compact_dawg_full(std::istream *input_stream, std::ostream *output_st
     time_t start = time(NULL);
 
     while (std::getline(*input_stream, word)) {
-        if (!word.length()) {
+        if (word.empty()) {
             continue;
         }
         word_count += 1;
 
-        if (!dawg.insert(word)) return false;
+        if (!dawg.insert(word.data(),word.size())) return false;
 
         if (verbose && word_count % 100 == 0) {
             cout << word_count << "\r";

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -64,7 +64,8 @@ void write_node(shared_ptr<DawgNode> node, std::vector<unsigned char>* output, s
         i++;
     }
 
-    for (size_t i = 0; i < nodes_to_process.size(); i++) {
+    size_t num_nodes = nodes_to_process.size();
+    for (size_t i = 0; i < num_nodes; i++) {
         write_node(nodes_to_process[i], output, edge_locs, node_locs);
     }
 }
@@ -89,7 +90,8 @@ void build_compact_dawg(Dawg* dawg, std::vector<unsigned char>* output, bool ver
         cout << "Rewriting offsets...\n";
     }
 
-    for (size_t i = 0; i < edge_locs.size(); i++) {
+    size_t num_edges = edge_locs.size();
+    for (size_t i = 0; i < num_edges; i++) {
         unsigned int edge_offset = edge_locs[i];
 
         unsigned int flagged_id;

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -38,9 +38,9 @@ void write_node(shared_ptr<DawgNode> node, std::vector<unsigned char>* output, s
     std::vector<std::shared_ptr<DawgNode> > nodes_to_process;
     std::shared_ptr<DawgNode> child;
     int i = 0;
-    for (std::map<unsigned char, std::shared_ptr<DawgNode> >::iterator it = node->edges.begin(); it != node->edges.end(); ++it) {
-        char edge_key = it->first;
-        child = it->second;
+    for (auto const& edge : node->edges) {
+        char edge_key = edge.first;
+        child = edge.second;
 
         int edge_offset = (i * 5) + offset + 1;
         unsigned int node_id, flagged_id;

--- a/src/crc32c.hpp
+++ b/src/crc32c.hpp
@@ -36,7 +36,7 @@ static const uint32_t crc32cLookup[256] = {
     0x79B737BA,0x8BDCB4B9,0x988C474D,0x6AE7C44E,0xBE2DA0A5,0x4C4623A6,0x5F16D052,0xAD7D5351,
 };
 
-uint32_t crc32c(const void* data, size_t length, uint32_t previousCrc32 = 0) {
+inline uint32_t crc32c(const void* data, size_t length, uint32_t previousCrc32 = 0) {
     uint32_t crc = ~previousCrc32;
     unsigned char* current = (unsigned char*) data;
     while (length--) crc = (crc >> 8) ^ crc32cLookup[(crc & 0xFF) ^ *current++];

--- a/src/crc32c.hpp
+++ b/src/crc32c.hpp
@@ -39,7 +39,10 @@ static const uint32_t crc32cLookup[256] = {
 inline uint32_t crc32c(const void* data, size_t length, uint32_t previousCrc32 = 0) {
     uint32_t crc = ~previousCrc32;
     unsigned char* current = (unsigned char*) data;
-    while (length--) crc = (crc >> 8) ^ crc32cLookup[(crc & 0xFF) ^ *current++];
+    while (length > 0) {
+        crc = (crc >> 8) ^ crc32cLookup[(crc & 0xFF) ^ *current++];
+        --length;
+    }
     return ~crc;
 }
 

--- a/src/dawg.cpp
+++ b/src/dawg.cpp
@@ -85,8 +85,8 @@ class Dawg {
         Dawg();
         bool insert(const char * data, std::size_t len);
         void finish();
-        bool lookup(std::string word);
-        bool lookup_prefix(std::string word);
+        bool lookup(const char * data, std::size_t len);
+        bool lookup_prefix(const char * data, std::size_t len);
         uint edge_count();
         uint node_count();
     private:
@@ -170,12 +170,11 @@ void Dawg::_minimize(int down_to) {
     }
 }
 
-bool Dawg::lookup(std::string word) {
+bool Dawg::lookup(const char * data, std::size_t len) {
     std::shared_ptr<DawgNode> node = root;
 
-    char letter;
-    for (uint i = 0; i < word.length(); i++) {
-        letter = word[i];
+    for (uint i = 0; i < len; i++) {
+        char letter = data[i];
         if (node->edges.count(letter) == 0) {
             return false;
         } else {
@@ -189,11 +188,11 @@ bool Dawg::lookup(std::string word) {
     return false;
 }
 
-bool Dawg::lookup_prefix(std::string word) {
+bool Dawg::lookup_prefix(const char * data, std::size_t len) {
     std::shared_ptr<DawgNode> node = root;
 
-    for (uint i = 0; i < word.length(); i++) {
-        char letter = word[i];
+    for (uint i = 0; i < len; i++) {
+        char letter = data[i];
         if (node->edges.count(letter) == 0) {
             return false;
         } else {

--- a/src/dawg.cpp
+++ b/src/dawg.cpp
@@ -24,16 +24,10 @@ class DawgNode {
             out += "0_";
         }
 
-        char label;
-        std::shared_ptr<DawgNode> child;
         for (auto const& edge : edges) {
-            label = edge.first;
-            child = edge.second;
-
-            out.push_back(label);
+            out.push_back(edge.first);
             out.push_back('_');
-
-            out += std::to_string(child->id);
+            out += std::to_string(edge.second->id);
             out.push_back('_');
         }
 

--- a/src/dawg.cpp
+++ b/src/dawg.cpp
@@ -75,7 +75,7 @@ class Dawg {
         std::unordered_map<std::string, std::shared_ptr<DawgNode> > minimized_nodes;
         int node_counter;
         Dawg();
-        bool insert(std::string word);
+        bool insert(const char * data, std::size_t len);
         void finish();
         bool lookup(std::string word);
         bool lookup_prefix(std::string word);
@@ -91,7 +91,8 @@ Dawg::Dawg() {
     root = std::make_shared<DawgNode>();
 }
 
-bool Dawg::insert(std::string word) {
+bool Dawg::insert(const char* data, std::size_t len) {
+    std::string word(data,len);
     // This does lexigraphical compare
     // http://en.cppreference.com/w/cpp/algorithm/lexicographical_compare
     if (word <= previous_word) {
@@ -100,7 +101,7 @@ bool Dawg::insert(std::string word) {
 
     // find common prefix between word and previous word
     unsigned int common_prefix = 0;
-    unsigned int range = std::min(word.length(), previous_word.length());
+    unsigned int range = std::min(len, previous_word.length());
     for (uint i = 0; i < range; i++) {
         if (word[i] != previous_word[i]) {
             break;
@@ -123,7 +124,7 @@ bool Dawg::insert(std::string word) {
     }
 
     DawgNodeCheckEntry check_entry;
-    for (size_t i = common_prefix; i < word.length(); i++) {
+    for (size_t i = common_prefix; i < len; i++) {
         char letter = word[i];
 
         std::shared_ptr<DawgNode> next_node = std::make_shared<DawgNode>();
@@ -141,7 +142,7 @@ bool Dawg::insert(std::string word) {
     }
 
     node->final = true;
-    previous_word = word;
+    previous_word = std::move(word);
 
     return true;
 }

--- a/src/dawg.cpp
+++ b/src/dawg.cpp
@@ -11,6 +11,7 @@ class DawgNode {
         unsigned int id;
         bool final;
         std::map<unsigned char, std::shared_ptr<DawgNode> > edges;
+        // Number of end nodes reachable from this one.
         unsigned int count;
         DawgNode();
         uint num_reachable();
@@ -36,13 +37,10 @@ class DawgNode {
     }
 };
 
-DawgNode::DawgNode() {
-    id = 0;
-    final = false;
-
-    // Number of end nodes reachable from this one.
-    count = 0;
-}
+DawgNode::DawgNode() :
+  id(0),
+  final(false),
+  count(0) { }
 
 uint DawgNode::num_reachable() {
     // if a count is already assigned, return it
@@ -95,11 +93,10 @@ class Dawg {
         void _minimize(int down_to);
 };
 
-Dawg::Dawg() {
-    previous_word = "";
-    node_counter = 1;
-    root = std::make_shared<DawgNode>();
-}
+Dawg::Dawg() :
+  previous_word(),
+  root(std::make_shared<DawgNode>()),
+  node_counter(1) { }
 
 bool Dawg::insert(const char* data, std::size_t len) {
     std::string word(data,len);

--- a/src/dawg.cpp
+++ b/src/dawg.cpp
@@ -156,7 +156,8 @@ void Dawg::finish() {
 void Dawg::_minimize(int down_to) {
     // proceed from the leaf up to a certain point
 
-    for (int i = unchecked_nodes.size() - 1; i >= down_to; i--) {
+    int num_unchecked = static_cast<int>(unchecked_nodes.size());
+    for (int i = num_unchecked - 1; i >= down_to; i--) {
         DawgNodeCheckEntry & to_check = unchecked_nodes[i];
         std::string child_string = to_check.child->to_string();
         if (minimized_nodes.count(child_string) > 0) {

--- a/src/dawg.cpp
+++ b/src/dawg.cpp
@@ -1,6 +1,5 @@
 // based on python code by Steve Hanov, 2011
 
-#include <exception>
 #include <algorithm>
 #include <map>
 #include <unordered_map>
@@ -16,7 +15,7 @@ class DawgNode {
         DawgNode();
         uint num_reachable();
 
-    operator std::string() {
+    std::string to_string() {
         std::string out = "";
         if (final) {
             out += "1_";
@@ -93,6 +92,8 @@ Dawg::Dawg() {
 }
 
 bool Dawg::insert(std::string word) {
+    // This does lexigraphical compare
+    // http://en.cppreference.com/w/cpp/algorithm/lexicographical_compare
     if (word <= previous_word) {
         return false;
     }
@@ -155,12 +156,10 @@ void Dawg::finish() {
 
 void Dawg::_minimize(int down_to) {
     // proceed from the leaf up to a certain point
-    DawgNodeCheckEntry to_check;
-    std::string child_string;
 
     for (int i = unchecked_nodes.size() - 1; i >= down_to; i--) {
-        to_check = unchecked_nodes[i];
-        child_string = (*(to_check.child)).operator std::string();
+        DawgNodeCheckEntry & to_check = unchecked_nodes[i];
+        std::string child_string = to_check.child->to_string();
         if (minimized_nodes.count(child_string) > 0) {
             // replace the child with the previously encountered one
             to_check.parent->edges[to_check.letter] = minimized_nodes[child_string];

--- a/src/dawg.cpp
+++ b/src/dawg.cpp
@@ -37,7 +37,7 @@ class DawgNode {
     }
 };
 
-DawgNode::DawgNode(void) {
+DawgNode::DawgNode() {
     id = 0;
     final = false;
 
@@ -45,7 +45,7 @@ DawgNode::DawgNode(void) {
     count = 0;
 }
 
-uint DawgNode::num_reachable(void) {
+uint DawgNode::num_reachable() {
     // if a count is already assigned, return it
     if (count) return count;
 
@@ -86,7 +86,7 @@ class Dawg {
         void _minimize(int down_to);
 };
 
-Dawg::Dawg(void) {
+Dawg::Dawg() {
     previous_word = "";
     node_counter = 1;
     root = std::make_shared<DawgNode>();

--- a/test/dawg.test.js
+++ b/test/dawg.test.js
@@ -4,8 +4,23 @@ var queue = require('queue-async');
 var zlib = require('zlib');
 var forOf = require('es6-iterator/for-of');
 require('collections/collections.js');
+var binding = require("../lib/jsdawg.node");
 
 var jsdawg = require("../index");
+
+test('DAWG test invalid usage', function (t) {
+    var dawg = new jsdawg.Dawg();
+    t.throws(function() { dawg.insert(null) }, /first argument must be a String/, "validates inserted value");
+    t.throws(function() { dawg.insert({}) }, /first argument must be a String/, "validates inserted value");
+    t.throws(function() { dawg.insert(1.0) }, /first argument must be a String/, "validates inserted value");
+    t.throws(function() { dawg.insert(function(){}) }, /first argument must be a String/, "validates inserted value");
+    dawg.finish();
+    t.throws(function() { binding.compactDawgBufferLookup(); }, /first argument must be a Buffer/, "validates inserted value");
+    t.throws(function() { binding.compactDawgBufferLookup(new Buffer(0)); }, /second argument must be a String/, "validates inserted value");
+    var compactDawg = dawg.toCompactDawg();
+    t.throws(function() { compactDawg.lookupPrefix(); }, /second argument must be a String/, "validates inserted value");
+    t.end();
+});
 
 test('DAWG test', function (t) {
     var q = queue(1);

--- a/test/dawg.test.js
+++ b/test/dawg.test.js
@@ -18,13 +18,11 @@ test('DAWG test invalid usage', function (t) {
     t.throws(function() { dawg.lookupPrefix(null) }, /first argument must be a String/, "validates inserted value");
     t.throws(function() { dawg.insert('') }, /empty string passed to insert/, "validates inserted value");
     dawg.finish();
-    t.throws(function() { binding.compactDawgBufferLookup(); }, /first argument must be a Buffer/, "validates inserted value");
-    t.throws(function() { binding.compactDawgBufferLookup({},''); }, /first argument must be a Buffer/, "validates inserted value");
-    t.throws(function() { binding.compactDawgBufferLookup(null); }, /first argument must be a Buffer/, "validates inserted value");
-    t.throws(function() { binding.compactDawgBufferLookup(undefined); }, /first argument must be a Buffer/, "validates inserted value");
-    t.throws(function() { binding.compactDawgBufferLookup(new Buffer(0)); }, /second argument must be a String/, "validates inserted value");
     var compactDawg = dawg.toCompactDawg();
-    t.throws(function() { compactDawg.lookupPrefix(); }, /second argument must be a String/, "validates inserted value");
+    t.assert(compactDawg.lookup() == '');
+    t.assert(compactDawg.lookupPrefix() == '');
+    t.assert(compactDawg.lookup({}) == '');
+    t.assert(compactDawg.lookupPrefix({}) == '');
     t.end();
 });
 

--- a/test/dawg.test.js
+++ b/test/dawg.test.js
@@ -121,7 +121,8 @@ test('DAWG test', function (t) {
         t.assert(prefixLookup, "compact dawg contains prefixes of all words as prefixes");
 
         var compactDawgWords = [];
-        forOf(compactDawg, function(value) { compactDawgWords.push(value); });
+        var iterable = dawg.toCompactDawgIterator();
+        forOf(iterable, function(value) { compactDawgWords.push(value); });
         var iteratorLookup = true;
         for (var i = 0; i < words.length; i++) {
             iteratorLookup = iteratorLookup && (words[i] == compactDawgWords[i]);
@@ -129,7 +130,7 @@ test('DAWG test', function (t) {
         t.assert(iteratorLookup, "compact dawg iterator reproduces original list");
 
         var prefixWords = [];
-        var prefixIterator = compactDawg.iterator("test");
+        var prefixIterator = iterable.iterator("test");
         var priNext = prefixIterator.next();
         while (!priNext.done) {
             prefixWords.push(priNext.value);
@@ -139,7 +140,7 @@ test('DAWG test', function (t) {
         t.assert(prefixWords.indexOf("test") == 0, "submitted prefix 'test' is included in results");
 
         var prefixWords = [];
-        var prefixIterator = compactDawg.iterator("testac");
+        var prefixIterator = iterable.iterator("testac");
         var priNext = prefixIterator.next();
         while (!priNext.done) {
             prefixWords.push(priNext.value);
@@ -149,7 +150,7 @@ test('DAWG test', function (t) {
         t.assert(prefixWords.indexOf("testac") == -1, "submitted prefix 'testac' is not included in results");
 
         var prefixWords = [];
-        var prefixIterator = compactDawg.iterator("testaaa");
+        var prefixIterator = iterable.iterator("testaaa");
         var priNext = prefixIterator.next();
         while (!priNext.done) {
             prefixWords.push(priNext.value);

--- a/test/dawg.test.js
+++ b/test/dawg.test.js
@@ -16,6 +16,7 @@ test('DAWG test invalid usage', function (t) {
     t.throws(function() { dawg.insert(function(){}) }, /first argument must be a String/, "validates inserted value");
     t.throws(function() { dawg.lookup(null) }, /first argument must be a String/, "validates inserted value");
     t.throws(function() { dawg.lookupPrefix(null) }, /first argument must be a String/, "validates inserted value");
+    t.throws(function() { dawg.insert('') }, /empty string passed to insert/, "validates inserted value");
     dawg.finish();
     t.throws(function() { binding.compactDawgBufferLookup(); }, /first argument must be a Buffer/, "validates inserted value");
     t.throws(function() { binding.compactDawgBufferLookup(new Buffer(0)); }, /second argument must be a String/, "validates inserted value");

--- a/test/dawg.test.js
+++ b/test/dawg.test.js
@@ -19,6 +19,9 @@ test('DAWG test invalid usage', function (t) {
     t.throws(function() { dawg.insert('') }, /empty string passed to insert/, "validates inserted value");
     dawg.finish();
     t.throws(function() { binding.compactDawgBufferLookup(); }, /first argument must be a Buffer/, "validates inserted value");
+    t.throws(function() { binding.compactDawgBufferLookup({},''); }, /first argument must be a Buffer/, "validates inserted value");
+    t.throws(function() { binding.compactDawgBufferLookup(null); }, /first argument must be a Buffer/, "validates inserted value");
+    t.throws(function() { binding.compactDawgBufferLookup(undefined); }, /first argument must be a Buffer/, "validates inserted value");
     t.throws(function() { binding.compactDawgBufferLookup(new Buffer(0)); }, /second argument must be a String/, "validates inserted value");
     var compactDawg = dawg.toCompactDawg();
     t.throws(function() { compactDawg.lookupPrefix(); }, /second argument must be a String/, "validates inserted value");

--- a/test/dawg.test.js
+++ b/test/dawg.test.js
@@ -14,6 +14,8 @@ test('DAWG test invalid usage', function (t) {
     t.throws(function() { dawg.insert({}) }, /first argument must be a String/, "validates inserted value");
     t.throws(function() { dawg.insert(1.0) }, /first argument must be a String/, "validates inserted value");
     t.throws(function() { dawg.insert(function(){}) }, /first argument must be a String/, "validates inserted value");
+    t.throws(function() { dawg.lookup(null) }, /first argument must be a String/, "validates inserted value");
+    t.throws(function() { dawg.lookupPrefix(null) }, /first argument must be a String/, "validates inserted value");
     dawg.finish();
     t.throws(function() { binding.compactDawgBufferLookup(); }, /first argument must be a Buffer/, "validates inserted value");
     t.throws(function() { binding.compactDawgBufferLookup(new Buffer(0)); }, /second argument must be a String/, "validates inserted value");


### PR DESCRIPTION
Perf improvements:

 - Avoids or reduces `std::string` allocation in several places
 - Reduces unnecessary reference counting of `std::shared_ptr` by avoiding unneeded copies of `DawgNodeCheckEntry`
 - Uses `std::move` to move strings instead of copying

Other non-performance focused improvements:

 - Use C++11 `for` loops for better readability
 - Starts validating arguments