### PR TITLE
[dead] Prefix continuations

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,10 @@ CompactDawg.prototype.lookup = function(prefix) {
     return binding.compactDawgBufferLookup(this.data, prefix) == 2;
 }
 
+CompactDawg.prototype.prefixContinuations = function(prefix, maxDepth) {
+    return binding.prefixContinuations(this.data, prefix, maxDepth);
+}
+
 CompactDawg.prototype.iterator = function(prefix) {
     // implement the ES6 iterator pattern
     var it = prefix ? new binding.CompactDawgIterator(this.data, prefix) : new binding.CompactDawgIterator(this.data);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dawg-cache",
-  "version": "0.3.1",
+  "version": "0.3.1-prefix-1",
   "description": "Javascript/C++ DAWG implementation",
   "main": "index.js",
   "private": false,

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -373,6 +373,78 @@ class CompactIterator : public Nan::ObjectWrap {
     }
 };
 
+void prefix_recurse(unsigned const char* data, int node_offset, uint32_t remaining_depth, std::string working, std::vector<std::string>* results) {
+    unsigned int flagged_offset, node_final = 0;
+    int next_node_offset, edge_count, edge_offset;
+    char letter;
+
+    edge_count = (int) data[node_offset];
+    std::string next;
+
+    for (int i = 0; i < edge_count; i++) {
+        edge_offset = node_offset + 1 + (5 * i);
+        letter = data[edge_offset];
+
+        memcpy(&flagged_offset, &(data[edge_offset + 1]), sizeof(unsigned int));
+        next_node_offset = (int)(flagged_offset & FINAL_MASK);
+        node_final = flagged_offset & IS_FINAL_FLAG;
+
+        next = working + letter;
+        if (node_final || remaining_depth == 0) {
+            results->emplace_back(next);
+        }
+        if (node_offset != 0 && remaining_depth > 0) {
+            prefix_recurse(data, next_node_offset, remaining_depth - 1, next, results);
+        }
+    }
+}
+
+NAN_METHOD(PrefixContinuations) {
+    if (info.Length() != 3) {
+        Nan::ThrowTypeError("Invalid number of arguments");
+        return;
+    }
+
+    v8::Local<v8::Object> bufferObj;
+    if (node::Buffer::HasInstance(info[0])) {
+        bufferObj = info[0]->ToObject();
+    } else {
+        Nan::ThrowTypeError("Input must be a buffer");
+        return;
+    }
+    unsigned char* full_data = (unsigned char*) node::Buffer::Data(bufferObj);
+    unsigned char* data = full_data + DAWG_HEADER_SIZE;
+
+    String::Utf8Value utf8_value(info[1].As<String>());
+    const char* search = (const char*) *utf8_value;
+    std::string ssearch(search);
+
+    int32_t search_length = utf8_value.length();
+    int32_t max_depth = info[2]->IntegerValue();
+    int32_t remaining_depth = max_depth - search_length;
+    std::vector<std::string> output;
+
+    if (remaining_depth >= 0) {
+        dawg_search_result result = compact_dawg_search(data, (unsigned char*) search, search_length);
+
+        if (result.found) {
+            if (result.final) {
+                output.emplace_back(ssearch);
+            }
+            if (result.node_offset != -1 && remaining_depth > 0) {
+                prefix_recurse(data, result.node_offset, remaining_depth - 1, ssearch, &output);
+            }
+        }
+    }
+
+    std::size_t vsize = output.size();
+    v8::Local<v8::Array> array = Nan::New<v8::Array>(static_cast<int>(vsize));
+    for (uint32_t i = 0; i < vsize; i++) {
+        array->Set(i, Nan::New(output[i]).ToLocalChecked());
+    }
+    info.GetReturnValue().Set(array);
+}
+
 NAN_METHOD(Crc32c) {
     Nan::HandleScope scope;
     uint32_t crc;
@@ -400,6 +472,11 @@ static NAN_MODULE_INIT(Init) {
         target,
         Nan::New("compactDawgBufferLookup").ToLocalChecked(),
         Nan::GetFunction(New<FunctionTemplate>(CompactLookup)).ToLocalChecked()
+    );
+    Nan::Set(
+        target,
+        Nan::New("prefixContinuations").ToLocalChecked(),
+        Nan::GetFunction(New<FunctionTemplate>(PrefixContinuations)).ToLocalChecked()
     );
     Nan::Set(
         target,

--- a/test/dawg.test.js
+++ b/test/dawg.test.js
@@ -159,6 +159,23 @@ test('DAWG test', function (t) {
         t.assert(!compactDawg.lookup(""), "compact dawg does not contain the empty string as a term");
         t.assert(compactDawg.lookupPrefix(""), "compact dawg does contain the empty string as a prefix");
 
+        // hacky equivalently functional continuation calculator that just iterates over the array
+        var manualContinuations = function(prefix, maxDepth) {
+            if (prefix.length > maxDepth) return [];
+            var matches = words.filter(function(w) { return w.substring(0, prefix.length) == prefix });
+            var obj = {}
+            matches.forEach(function (w) {
+                obj[w.substr(0, maxDepth)] = true;
+            })
+            return Object.keys(obj).sort();
+        }
+
+        t.deepEqual(compactDawg.prefixContinuations("a", 3), manualContinuations("a", 3), "prefix continuations correctly calculated for ('a', 3)");
+        t.deepEqual(compactDawg.prefixContinuations("ab", 3), manualContinuations("ab", 3), "prefix continuations correctly calculated for ('ab', 3)");
+        t.deepEqual(compactDawg.prefixContinuations("aba", 3), ['aba'], "'aba' the sole prefix continuation result for ('aba', 3)")
+        t.deepEqual(compactDawg.prefixContinuations("abac", 3), [], "prefix continuation search returns no results for ('abac', 3) [too long]")
+        t.deepEqual(compactDawg.prefixContinuations("zz", 3), [], "prefix continuation search returns no results for ('zz', 3) [no match]")
+
         callback();
     })
 


### PR DESCRIPTION
I'm opening this PR with the intention of immediately closing it without merging, but want to preserve for posterity in case this code is ever useful later.

This branch allowed for an efficient partial traversal of the DAWG to determine all bounded-length continuations of a given prefix that occurred within the graph. So, as a concrete example, you could determine all the four-character prefixes of words in a graph that started with a given two-character prefix, without walking all the way out to the leaves of the graph.

This would have been useful for a carmen sharding strategy that we've now abandoned, and is niche and weird so unlikely to be useful for much else. The code is interesting because it has an example of recursive graph traversal though, which is much cleaner and less gross than the explicit stack/iteration approach we use elsewhere in this library, so I could imagine someone might want to raid this branch for code for some other purpose in the future.