### PR TITLE
Reintroduce CompactDawg.prototype.iterator

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,26 @@ binding.CompactDawg.prototype.lookup = function(prefix) {
     return this._lookup(prefix) == 2;
 }
 
+binding.CompactDawg.prototype.iterator = function(prefix) {
+    // implement the ES6 iterator pattern
+    var it = prefix ? this._iterator(prefix) : this._iterator();
+    return {
+        next: prefix ?
+            function() {
+                var n = it.next();
+                out = {done: n === undefined};
+                out.value = out.done ? n : prefix + n;
+                return out;
+            } :
+            function() {
+                var n = it.next();
+                return {value: n, done: n === undefined};
+            }
+    }
+}
+
+binding.CompactDawg.prototype[Symbol.iterator] = binding.CompactDawg.prototype.iterator;
+
 var CompactDawgIterator = function(buf) {
     this.data = buf;
 }

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -472,8 +472,7 @@ class CompactDawg : public Nan::ObjectWrap {
         v8::Local<v8::Object> buf = Nan::New(obj->persistentBuffer);
         v8::Local<v8::Value> val(buf);
 
-        bool prefix = info.Length() > 0;
-        if (prefix) {
+        if (info.Length() > 0) {
             v8::Local<v8::Value> argv[2] = {val, info[0]};
             info.GetReturnValue().Set(Nan::NewInstance(
                 Nan::New(CompactIterator::constructor()),

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -207,111 +207,6 @@ dawg_search_result compact_dawg_search(unsigned char* data, unsigned char* searc
 
 constexpr std::size_t arena_size = 1024;
 
-class CompactDawg : public Nan::ObjectWrap {
-    public:
-        static void Init(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
-            v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
-            tpl->SetClassName(Nan::New("CompactDawg").ToLocalChecked());
-            tpl->InstanceTemplate()->SetInternalFieldCount(1);
-            SetPrototypeMethod(tpl, "_lookup", Lookup);
-            constructor().Reset(Nan::GetFunction(tpl).ToLocalChecked());
-            Nan::Set(
-                target,
-                Nan::New("CompactDawg").ToLocalChecked(),
-                Nan::GetFunction(tpl).ToLocalChecked()
-            );
-        }
-    private:
-        explicit CompactDawg(v8::Local<v8::Object> buf)
-          : data(node::Buffer::Data(buf) + DAWG_HEADER_SIZE),
-            len(node::Buffer::Length(buf)),
-            persistentBuffer() {
-              persistentBuffer.Reset(buf);
-          }
-        ~CompactDawg() { persistentBuffer.Reset(); }
-        char* data;
-        size_t len;
-        Nan::Persistent<v8::Object> persistentBuffer;
-
-    static NAN_METHOD(New) {
-        if (info.IsConstructCall()) {
-            if (info.Length() != 1) {
-                Nan::ThrowTypeError("Invalid number of arguments");
-                return;
-            }
-
-            v8::Local<v8::Value> obj = info[0];
-            if (!obj->IsObject()) {
-                return Nan::ThrowTypeError("first argument must be a Buffer");
-            }
-
-            if (!node::Buffer::HasInstance(obj)) {
-                Nan::ThrowTypeError("Input must be a buffer");
-                return;
-            }
-
-            CompactDawg *dawg = new CompactDawg(obj->ToObject());
-            dawg->Wrap(info.This());
-            info.GetReturnValue().Set(info.This());
-        } else {
-            Nan::ThrowTypeError("CompactDawg needs to be called as a constructor");
-        }
-    }
-
-    static NAN_METHOD(Lookup) {
-        CompactDawg* obj = Nan::ObjectWrap::Unwrap<CompactDawg>(info.This());
-        v8::Local<v8::Value> js_val = info[0];
-        std::uint32_t return_val = 1;
-        // https://github.com/nodejs/node/commit/44a40325da4031f5a5470bec7b07fb8be5f9e99e
-        // https://github.com/nodejs/node/pull/1042
-        if (!js_val.IsEmpty()) {
-            v8::Local<v8::String> js_str = js_val->ToString();
-            if (!js_str.IsEmpty()) {
-                int js_str_len = js_str->Length();
-                if (js_str_len > 0) {
-                    // Also passing v8::String::HINT_MANY_WRITES_EXPECTED flattens string
-                    // but I've not enabled this yet as it does not clearly increase performance
-                    const int flags =
-                        v8::String::NO_NULL_TERMINATION | v8::String::REPLACE_INVALID_UTF8;
-                    // max possible decoded utf length
-                    // much faster than calling `str->Utf8Length();` to get exact length
-                    // https://github.com/nodejs/node/blob/bfd3c7e626306cc5793618da2b56d37df338eb05/src/string_bytes.cc#L392
-                    std::size_t len = (3 * js_str_len) + 1;
-                    if (len > arena_size) {
-                        char * heap_string = static_cast<char *>(std::malloc(len));
-                        std::size_t utf8_length = js_str->WriteUtf8(heap_string, static_cast<int>(len), 0, flags);
-                        heap_string[utf8_length] = '\0';
-                        dawg_search_result result = compact_dawg_search((unsigned char*)obj->data, (unsigned char*)heap_string, utf8_length);
-                        if (result.found) {
-                            return_val = result.final ? 2 : 1;
-                        } else {
-                            return_val = 0;
-                        }
-                        free(heap_string);
-                    } else {
-                        char arena[arena_size];
-                        std::size_t utf8_length = js_str->WriteUtf8(arena, static_cast<int>(len), 0, flags);
-                        arena[utf8_length] = '\0';
-                        dawg_search_result result = compact_dawg_search((unsigned char*)obj->data, (unsigned char*)arena, utf8_length);
-                        if (result.found) {
-                            return_val = result.final ? 2 : 1;
-                        } else {
-                            return_val = 0;
-                        }
-                    }
-                }
-            }
-        }
-        info.GetReturnValue().Set(return_val);
-        return;
-        }
-
-    static inline Nan::Persistent<v8::Function> & constructor() {
-        static Nan::Persistent<v8::Function> my_constructor;
-        return my_constructor;
-    }
-};
-
 class CompactIterator : public Nan::ObjectWrap {
     public:
         static void Init(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
@@ -328,6 +223,12 @@ class CompactIterator : public Nan::ObjectWrap {
                 Nan::GetFunction(tpl).ToLocalChecked()
             );
         }
+
+        static inline Nan::Persistent<v8::Function> & constructor() {
+            static Nan::Persistent<v8::Function> my_constructor;
+            return my_constructor;
+        }
+
     private:
         explicit CompactIterator() {}
         ~CompactIterator() { persistentBuffer.Reset(); }
@@ -462,6 +363,130 @@ class CompactIterator : public Nan::ObjectWrap {
             info.GetReturnValue().Set(Nan::New(output).ToLocalChecked());
         }
 
+        return;
+    }
+};
+
+class CompactDawg : public Nan::ObjectWrap {
+    public:
+        static void Init(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target) {
+            v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
+            tpl->SetClassName(Nan::New("CompactDawg").ToLocalChecked());
+            tpl->InstanceTemplate()->SetInternalFieldCount(1);
+            SetPrototypeMethod(tpl, "_lookup", Lookup);
+            SetPrototypeMethod(tpl, "_iterator", Iterator);
+            constructor().Reset(Nan::GetFunction(tpl).ToLocalChecked());
+            Nan::Set(
+                target,
+                Nan::New("CompactDawg").ToLocalChecked(),
+                Nan::GetFunction(tpl).ToLocalChecked()
+            );
+        }
+    private:
+        explicit CompactDawg(v8::Local<v8::Object> buf)
+          : data(node::Buffer::Data(buf) + DAWG_HEADER_SIZE),
+            len(node::Buffer::Length(buf)),
+            persistentBuffer() {
+              persistentBuffer.Reset(buf);
+          }
+        ~CompactDawg() { persistentBuffer.Reset(); }
+        char* data;
+        size_t len;
+        Nan::Persistent<v8::Object> persistentBuffer;
+
+    static NAN_METHOD(New) {
+        if (info.IsConstructCall()) {
+            if (info.Length() != 1) {
+                Nan::ThrowTypeError("Invalid number of arguments");
+                return;
+            }
+
+            v8::Local<v8::Value> obj = info[0];
+            if (!obj->IsObject()) {
+                return Nan::ThrowTypeError("first argument must be a Buffer");
+            }
+
+            if (!node::Buffer::HasInstance(obj)) {
+                Nan::ThrowTypeError("Input must be a buffer");
+                return;
+            }
+
+            CompactDawg *dawg = new CompactDawg(obj->ToObject());
+            dawg->Wrap(info.This());
+            info.GetReturnValue().Set(info.This());
+        } else {
+            Nan::ThrowTypeError("CompactDawg needs to be called as a constructor");
+        }
+    }
+
+    static NAN_METHOD(Lookup) {
+        CompactDawg* obj = Nan::ObjectWrap::Unwrap<CompactDawg>(info.This());
+        v8::Local<v8::Value> js_val = info[0];
+        std::uint32_t return_val = 1;
+        // https://github.com/nodejs/node/commit/44a40325da4031f5a5470bec7b07fb8be5f9e99e
+        // https://github.com/nodejs/node/pull/1042
+        if (!js_val.IsEmpty()) {
+            v8::Local<v8::String> js_str = js_val->ToString();
+            if (!js_str.IsEmpty()) {
+                int js_str_len = js_str->Length();
+                if (js_str_len > 0) {
+                    // Also passing v8::String::HINT_MANY_WRITES_EXPECTED flattens string
+                    // but I've not enabled this yet as it does not clearly increase performance
+                    const int flags =
+                        v8::String::NO_NULL_TERMINATION | v8::String::REPLACE_INVALID_UTF8;
+                    // max possible decoded utf length
+                    // much faster than calling `str->Utf8Length();` to get exact length
+                    // https://github.com/nodejs/node/blob/bfd3c7e626306cc5793618da2b56d37df338eb05/src/string_bytes.cc#L392
+                    std::size_t len = (3 * js_str_len) + 1;
+                    if (len > arena_size) {
+                        char * heap_string = static_cast<char *>(std::malloc(len));
+                        std::size_t utf8_length = js_str->WriteUtf8(heap_string, static_cast<int>(len), 0, flags);
+                        heap_string[utf8_length] = '\0';
+                        dawg_search_result result = compact_dawg_search((unsigned char*)obj->data, (unsigned char*)heap_string, utf8_length);
+                        if (result.found) {
+                            return_val = result.final ? 2 : 1;
+                        } else {
+                            return_val = 0;
+                        }
+                        free(heap_string);
+                    } else {
+                        char arena[arena_size];
+                        std::size_t utf8_length = js_str->WriteUtf8(arena, static_cast<int>(len), 0, flags);
+                        arena[utf8_length] = '\0';
+                        dawg_search_result result = compact_dawg_search((unsigned char*)obj->data, (unsigned char*)arena, utf8_length);
+                        if (result.found) {
+                            return_val = result.final ? 2 : 1;
+                        } else {
+                            return_val = 0;
+                        }
+                    }
+                }
+            }
+        }
+        info.GetReturnValue().Set(return_val);
+        return;
+    }
+
+    static NAN_METHOD(Iterator) {
+        CompactDawg* obj = Nan::ObjectWrap::Unwrap<CompactDawg>(info.This());
+        v8::Local<v8::Object> buf = Nan::New(obj->persistentBuffer);
+        v8::Local<v8::Value> val(buf);
+
+        bool prefix = info.Length() > 0;
+        if (prefix) {
+            v8::Local<v8::Value> argv[2] = {val, info[0]};
+            info.GetReturnValue().Set(Nan::NewInstance(
+                Nan::New(CompactIterator::constructor()),
+                2,
+                argv
+            ).ToLocalChecked());
+        } else {
+            info.GetReturnValue().Set(Nan::NewInstance(
+                Nan::New(CompactIterator::constructor()),
+                1,
+                &val
+            ).ToLocalChecked());
+        }
         return;
     }
 

--- a/test/dawg.test.js
+++ b/test/dawg.test.js
@@ -121,8 +121,8 @@ test('DAWG test', function (t) {
         t.assert(prefixLookup, "compact dawg contains prefixes of all words as prefixes");
 
         var compactDawgWords = [];
-        var iterable = dawg.toCompactDawgIterator();
-        forOf(iterable, function(value) { compactDawgWords.push(value); });
+        var compactDawg = dawg.toCompactDawg();
+        forOf(compactDawg, function(value) { compactDawgWords.push(value); });
         var iteratorLookup = true;
         for (var i = 0; i < words.length; i++) {
             iteratorLookup = iteratorLookup && (words[i] == compactDawgWords[i]);
@@ -130,7 +130,7 @@ test('DAWG test', function (t) {
         t.assert(iteratorLookup, "compact dawg iterator reproduces original list");
 
         var prefixWords = [];
-        var prefixIterator = iterable.iterator("test");
+        var prefixIterator = compactDawg.iterator("test");
         var priNext = prefixIterator.next();
         while (!priNext.done) {
             prefixWords.push(priNext.value);
@@ -140,7 +140,7 @@ test('DAWG test', function (t) {
         t.assert(prefixWords.indexOf("test") == 0, "submitted prefix 'test' is included in results");
 
         var prefixWords = [];
-        var prefixIterator = iterable.iterator("testac");
+        var prefixIterator = compactDawg.iterator("testac");
         var priNext = prefixIterator.next();
         while (!priNext.done) {
             prefixWords.push(priNext.value);
@@ -150,7 +150,7 @@ test('DAWG test', function (t) {
         t.assert(prefixWords.indexOf("testac") == -1, "submitted prefix 'testac' is not included in results");
 
         var prefixWords = [];
-        var prefixIterator = iterable.iterator("testaaa");
+        var prefixIterator = compactDawg.iterator("testaaa");
         var priNext = prefixIterator.next();
         while (!priNext.done) {
             prefixWords.push(priNext.value);


### PR DESCRIPTION
I hadn't realized when I merged https://github.com/mapbox/dawg-cache/pull/10 that it removes the CompactDawg.prototype.iterator method, and modifies tests to pass by instead instantiating iterator objects directly from buffers. We depend on that method in the carmen indexer, where we only have access to the CompactDawg objects and not to their underlying buffers.

This PR reintroduces that method from the C++ side. Most of the PR is noise from swapping the relative positions of CompactDawg and CompactDawgIterator. The substantive changes are moving CompactDawgIterator's `constructor` method to be public so that CompactDawg can call it, and adding the `Iterator` method to CompactDawg, which instantiates a CompactDawgIterator and passes it a reference to the buffer it's storing a persistent reference to.

cc @springmeyer : I think this should be pretty cut and dry but if you have a sec to make sure I'm not doing anything stupid I'd appreciate it.