### PR TITLE
Cleanups

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,11 +29,7 @@ function validate(buf) {
 binding.Dawg.prototype.toCompactDawg = function() {
     return new binding.CompactDawg(validate(this.toCompactDawgBuffer()));
 }
-
-binding.Dawg.prototype.toCompactDawgIterator = function() {
-    return new CompactDawgIterator(validate(this.toCompactDawgBuffer()));
-}
-
+    
 binding.CompactDawg.prototype.lookupPrefix = function(prefix) {
     return this._lookup(prefix) != 0;
 }
@@ -62,32 +58,7 @@ binding.CompactDawg.prototype.iterator = function(prefix) {
 
 binding.CompactDawg.prototype[Symbol.iterator] = binding.CompactDawg.prototype.iterator;
 
-var CompactDawgIterator = function(buf) {
-    this.data = buf;
-}
-
-CompactDawgIterator.prototype.iterator = function(prefix) {
-    // implement the ES6 iterator pattern
-    var it = prefix ? new binding.CompactDawgIterator(this.data, prefix) : new binding.CompactDawgIterator(this.data);
-    return {
-        next: prefix ?
-            function() {
-                var n = it.next();
-                out = {done: n === undefined};
-                out.value = out.done ? n : prefix + n;
-                return out;
-            } :
-            function() {
-                var n = it.next();
-                return {value: n, done: n === undefined};
-            }
-    }
-}
-
-CompactDawgIterator.prototype[Symbol.iterator] = CompactDawgIterator.prototype.iterator;
-
 module.exports = {
     Dawg: binding.Dawg,
-    CompactDawg: binding.CompactDawg,
-    CompactDawgIterator: CompactDawgIterator
+    CompactDawg: binding.CompactDawg
 };

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -470,20 +470,20 @@ class CompactDawg : public Nan::ObjectWrap {
     static NAN_METHOD(Iterator) {
         CompactDawg* obj = Nan::ObjectWrap::Unwrap<CompactDawg>(info.This());
         v8::Local<v8::Object> buf = Nan::New(obj->persistentBuffer);
-        v8::Local<v8::Value> val(buf);
 
         if (info.Length() > 0) {
-            v8::Local<v8::Value> argv[2] = {val, info[0]};
+            v8::Local<v8::Value> argv[2] = {buf, info[0]};
             info.GetReturnValue().Set(Nan::NewInstance(
                 Nan::New(CompactIterator::constructor()),
                 2,
                 argv
             ).ToLocalChecked());
         } else {
+            v8::Local<v8::Value> argv[1] = {buf};
             info.GetReturnValue().Set(Nan::NewInstance(
                 Nan::New(CompactIterator::constructor()),
                 1,
-                &val
+                argv
             ).ToLocalChecked());
         }
         return;


### PR DESCRIPTION
Followup to #13 and #10 as `CompactDawgIterator` looks unused now. It also makes a minor adjustment to the iterator C++ code to avoid creating one extra copy of a Local.

/cc @apendleton 