### PR TITLE
Fix prefix lookup for nonlatin characters

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -152,7 +152,7 @@ dawg_search_result compact_dawg_search(unsigned char* data, unsigned char* searc
     unsigned int flagged_offset, node_final = 0;
     int node_offset = 0, edge_count, edge_offset, min, max, guess;
     bool match = false;
-    char search_letter, letter;
+    unsigned char search_letter, letter;
 
     dawg_search_result output;
 
@@ -307,7 +307,7 @@ class CompactIterator : public Nan::ObjectWrap {
 
         unsigned int flagged_offset, next_final = 0;
         unsigned int next_offset = 0, edge_count, edge_offset;
-        char letter;
+        unsigned char letter;
 
         std::string output;
         bool has_output = false;
@@ -330,7 +330,7 @@ class CompactIterator : public Nan::ObjectWrap {
 
             if (next_final && !cur_visited) {
                 has_output = true;
-                output = std::string(current_word->begin(), current_word->end()) + letter;
+                output = std::string(current_word->begin(), current_word->end()) + reinterpret_cast<char &>(letter);
             }
 
             if (next_offset == 0 || cur_visited) {

--- a/test/dawg.test.js
+++ b/test/dawg.test.js
@@ -26,163 +26,180 @@ test('DAWG test invalid usage', function (t) {
     t.end();
 });
 
-test('DAWG test', function (t) {
-    var q = queue(1);
-    var resp, dawg, words, wordSet;
-    q.defer(function(callback) {
-        request.get({url: "http://mapbox.s3.amazonaws.com/apendleton/test_words.txt.gz", encoding: null}, function(err, response, body) {
-            if (err) throw "S3 fetch failed";
-            zlib.gunzip(body, function(err, data) {
-                if (err) throw ("Zlib decompression failed: " + err);
-                resp = data.toString();
-                callback();
+var resp, dawg, wordSet;
+var words = [];
+
+test('Prepare for DAWG tet', function (t) {
+    var q = queue();
+    ['test_words.txt.gz', 'nonlatin_words.txt.gz'].forEach(function(file) {
+        q.defer(function(callback) {
+            request.get({url: "http://mapbox.s3.amazonaws.com/apendleton/" + file, encoding: null}, function(err, response, body) {
+                if (err) throw "S3 fetch failed";
+                zlib.gunzip(body, function(err, data) {
+                    if (err) throw ("Zlib decompression failed: " + err);
+                    resp = data.toString();
+                    words = words.concat(resp.trim().split("\n"));
+                    callback();
+                })
             })
-        })
+        });
     });
-    q.defer(function(callback) {
-        words = resp.trim().split("\n");
-        wordSet = FastSet(words);
-
-        dawg = new jsdawg.Dawg();
-        for (var i = 0; i < words.length; i++) {
-            dawg.insert(words[i]);
-        }
-        t.pass("dawg created");
-
-        var exactLookup = true;
-        for (var i = 0; i < words.length; i++) {
-            exactLookup = exactLookup && dawg.lookup(words[i]);
-        }
-        t.assert(exactLookup, "dawg contains all words");
-
-        var prefixLookup = true;
-        for (var i = 0; i < words.length; i++) {
-            prefixLookup = prefixLookup && dawg.lookupPrefix(words[i]);
-        }
-        t.assert(prefixLookup, "dawg contains all words as prefixes");
-
-        var prefixLookup = true;
-        for (var i = 0; i < words.length; i++) {
-            if (words[i].length == 1) continue;
-
-            var prefix = words[i].substring(0, words[i].length - 1);
-            prefixLookup = prefixLookup && dawg.lookupPrefix(prefix);
-        }
-        t.assert(prefixLookup, "dawg contains prefixes of all words as prefixes");
-
-        var lookupFailure = true;
-        for (var i = 0; i < words.length; i++) {
-            lookupFailure = lookupFailure && (!dawg.lookup(words[i]) + "q");
-            lookupFailure = lookupFailure && (!dawg.lookupPrefix(words[i]) + "q");
-        }
-        t.assert(lookupFailure, "dawg does not contain any words with 'q' added to the end as term or prefix");
-
-        var prefixLookup = true;
-        for (var i = 0; i < words.length; i++) {
-            if (words[i].length == 1) continue;
-
-            var prefix = words[i].substring(0, words[i].length - 1);
-            // if this prefix is also a word, skip
-            if (wordSet.contains(prefix)) continue;
-            prefixLookup = prefixLookup && (!dawg.lookup(prefix));
-        }
-        t.assert(prefixLookup, "dawg does not contain prefixes of all words as terms");
-
-        t.assert(!dawg.lookup(""), "dawg does not contain the empty string as a term");
-        t.assert(dawg.lookupPrefix(""), "dawg does contain the empty string as a prefix");
-
-        callback();
-    });
-
-    q.defer(function(callback) {
-        dawg.finish();
-        var compactDawg = dawg.toCompactDawg();
-        t.pass("compact dawg created")
-
-        var exactLookup = true;
-        for (var i = 0; i < words.length; i++) {
-            exactLookup = exactLookup && compactDawg.lookup(words[i]);
-        }
-        t.assert(exactLookup, "compact dawg contains all words");
-
-        var prefixLookup = true;
-        for (var i = 0; i < words.length; i++) {
-            prefixLookup = prefixLookup && compactDawg.lookupPrefix(words[i]);
-        }
-        t.assert(prefixLookup, "compact dawg contains all words as prefixes");
-
-        var prefixLookup = true;
-        for (var i = 0; i < words.length; i++) {
-            if (words[i].length == 1) continue;
-
-            var prefix = words[i].substring(0, words[i].length - 1);
-            prefixLookup = prefixLookup && compactDawg.lookupPrefix(prefix);
-        }
-        t.assert(prefixLookup, "compact dawg contains prefixes of all words as prefixes");
-
-        var compactDawgWords = [];
-        var compactDawg = dawg.toCompactDawg();
-        forOf(compactDawg, function(value) { compactDawgWords.push(value); });
-        var iteratorLookup = true;
-        for (var i = 0; i < words.length; i++) {
-            iteratorLookup = iteratorLookup && (words[i] == compactDawgWords[i]);
-        }
-        t.assert(iteratorLookup, "compact dawg iterator reproduces original list");
-
-        var prefixWords = [];
-        var prefixIterator = compactDawg.iterator("test");
-        var priNext = prefixIterator.next();
-        while (!priNext.done) {
-            prefixWords.push(priNext.value);
-            priNext = prefixIterator.next();
-        }
-        t.assert(prefixWords.length == 82, "got 82 results for prefix 'test'");
-        t.assert(prefixWords.indexOf("test") == 0, "submitted prefix 'test' is included in results");
-
-        var prefixWords = [];
-        var prefixIterator = compactDawg.iterator("testac");
-        var priNext = prefixIterator.next();
-        while (!priNext.done) {
-            prefixWords.push(priNext.value);
-            priNext = prefixIterator.next();
-        }
-        t.assert(prefixWords.length == 7, "got 7 results for prefix 'testac'");
-        t.assert(prefixWords.indexOf("testac") == -1, "submitted prefix 'testac' is not included in results");
-
-        var prefixWords = [];
-        var prefixIterator = compactDawg.iterator("testaaa");
-        var priNext = prefixIterator.next();
-        while (!priNext.done) {
-            prefixWords.push(priNext.value);
-            priNext = prefixIterator.next();
-        }
-        t.assert(prefixWords.length == 0, "got 0 results for prefix 'testaaa'");
-
-        var lookupFailure = true;
-        for (var i = 0; i < words.length; i++) {
-            lookupFailure = lookupFailure && (!compactDawg.lookup(words[i]) + "q");
-            lookupFailure = lookupFailure && (!compactDawg.lookupPrefix(words[i]) + "q");
-        }
-        t.assert(lookupFailure, "compact dawg does not contain any words with 'q' added to the end as term or prefix");
-
-        var prefixLookup = true;
-        for (var i = 0; i < words.length; i++) {
-            if (words[i].length == 1) continue;
-
-            var prefix = words[i].substring(0, words[i].length - 1);
-            // if this prefix is also a word, skip
-            if (wordSet.contains(prefix)) continue;
-            prefixLookup = prefixLookup && (!compactDawg.lookup(prefix));
-        }
-        t.assert(prefixLookup, "compact dawg does not contain prefixes of all words as terms");
-
-        t.assert(!compactDawg.lookup(""), "compact dawg does not contain the empty string as a term");
-        t.assert(compactDawg.lookupPrefix(""), "compact dawg does contain the empty string as a prefix");
-
-        callback();
-    })
-
-    q.defer(function(callback) {
+    q.awaitAll(function() {
+        words.sort();
         t.end();
     });
+});
+
+test('Read-write DAWG test', function(t) {
+    wordSet = FastSet(words);
+
+    dawg = new jsdawg.Dawg();
+    for (var i = 0; i < words.length; i++) {
+        dawg.insert(words[i]);
+    }
+    t.pass("dawg created");
+
+    var exactLookup = true;
+    for (var i = 0; i < words.length; i++) {
+        exactLookup = exactLookup && dawg.lookup(words[i]);
+    }
+    t.assert(exactLookup, "dawg contains all words");
+
+    var prefixLookup = true;
+    for (var i = 0; i < words.length; i++) {
+        prefixLookup = prefixLookup && dawg.lookupPrefix(words[i]);
+    }
+    t.assert(prefixLookup, "dawg contains all words as prefixes");
+
+    var prefixLookup = true;
+    for (var i = 0; i < words.length; i++) {
+        if (words[i].length == 1) continue;
+
+        var prefix = words[i].substring(0, words[i].length - 1);
+        prefixLookup = prefixLookup && dawg.lookupPrefix(prefix);
+    }
+    t.assert(prefixLookup, "dawg contains prefixes of all words as prefixes");
+
+    var lookupFailure = true;
+    for (var i = 0; i < words.length; i++) {
+        lookupFailure = lookupFailure && (!dawg.lookup(words[i]) + "q");
+        lookupFailure = lookupFailure && (!dawg.lookupPrefix(words[i]) + "q");
+    }
+    t.assert(lookupFailure, "dawg does not contain any words with 'q' added to the end as term or prefix");
+
+    var prefixLookup = true;
+    for (var i = 0; i < words.length; i++) {
+        if (words[i].length == 1) continue;
+
+        var prefix = words[i].substring(0, words[i].length - 1);
+        // if this prefix is also a word, skip
+        if (wordSet.contains(prefix)) continue;
+        prefixLookup = prefixLookup && (!dawg.lookup(prefix));
+    }
+    t.assert(prefixLookup, "dawg does not contain prefixes of all words as terms");
+
+    t.assert(!dawg.lookup(""), "dawg does not contain the empty string as a term");
+    t.assert(dawg.lookupPrefix(""), "dawg does contain the empty string as a prefix");
+
+    t.end();
+});
+
+test('Compact DAWG test', function(t) {
+    dawg.finish();
+    var compactDawg = dawg.toCompactDawg();
+    t.pass("compact dawg created")
+
+    var exactLookup = true;
+    for (var i = 0; i < words.length; i++) {
+        exactLookup = exactLookup && compactDawg.lookup(words[i]);
+    }
+    t.assert(exactLookup, "compact dawg contains all words");
+
+    var prefixLookup = true;
+    for (var i = 0; i < words.length; i++) {
+        prefixLookup = prefixLookup && compactDawg.lookupPrefix(words[i]);
+    }
+    t.assert(prefixLookup, "compact dawg contains all words as prefixes");
+
+    var prefixLookup = true;
+    for (var i = 0; i < words.length; i++) {
+        if (words[i].length == 1) continue;
+
+        var prefix = words[i].substring(0, words[i].length - 1);
+        prefixLookup = prefixLookup && compactDawg.lookupPrefix(prefix);
+    }
+    t.assert(prefixLookup, "compact dawg contains prefixes of all words as prefixes");
+
+    var compactDawgWords = [];
+    var compactDawg = dawg.toCompactDawg();
+    forOf(compactDawg, function(value) { compactDawgWords.push(value); });
+    var iteratorLookup = true;
+    for (var i = 0; i < words.length; i++) {
+        iteratorLookup = iteratorLookup && (words[i] == compactDawgWords[i]);
+    }
+    t.assert(iteratorLookup, "compact dawg iterator reproduces original list");
+
+    var prefixWords = [];
+    var prefixIterator = compactDawg.iterator("test");
+    var priNext = prefixIterator.next();
+    while (!priNext.done) {
+        prefixWords.push(priNext.value);
+        priNext = prefixIterator.next();
+    }
+    t.equal(prefixWords.length, 82, "got 82 results for prefix 'test'");
+    t.assert(prefixWords.indexOf("test") == 0, "submitted prefix 'test' is included in results");
+
+    var prefixWords = [];
+    var prefixIterator = compactDawg.iterator("阿");
+    console.log(compactDawg.lookupPrefix("阿"))
+    var priNext = prefixIterator.next();
+    while (!priNext.done) {
+        prefixWords.push(priNext.value);
+        priNext = prefixIterator.next();
+    }
+    t.equal(prefixWords.length, 9, "got 82 results for prefix '阿'");
+    t.assert(prefixWords.indexOf("阿") == -1, "submitted prefix '阿' is not included in results");
+
+    var prefixWords = [];
+    var prefixIterator = compactDawg.iterator("testac");
+    var priNext = prefixIterator.next();
+    while (!priNext.done) {
+        prefixWords.push(priNext.value);
+        priNext = prefixIterator.next();
+    }
+    t.equal(prefixWords.length, 7, "got 7 results for prefix 'testac'");
+    t.assert(prefixWords.indexOf("testac") == -1, "submitted prefix 'testac' is not included in results");
+
+    var prefixWords = [];
+    var prefixIterator = compactDawg.iterator("testaaa");
+    var priNext = prefixIterator.next();
+    while (!priNext.done) {
+        prefixWords.push(priNext.value);
+        priNext = prefixIterator.next();
+    }
+    t.equal(prefixWords.length, 0, "got 0 results for prefix 'testaaa'");
+
+    var lookupFailure = true;
+    for (var i = 0; i < words.length; i++) {
+        lookupFailure = lookupFailure && (!compactDawg.lookup(words[i]) + "q");
+        lookupFailure = lookupFailure && (!compactDawg.lookupPrefix(words[i]) + "q");
+    }
+    t.assert(lookupFailure, "compact dawg does not contain any words with 'q' added to the end as term or prefix");
+
+    var prefixLookup = true;
+    for (var i = 0; i < words.length; i++) {
+        if (words[i].length == 1) continue;
+
+        var prefix = words[i].substring(0, words[i].length - 1);
+        // if this prefix is also a word, skip
+        if (wordSet.contains(prefix)) continue;
+        prefixLookup = prefixLookup && (!compactDawg.lookup(prefix));
+    }
+    t.assert(prefixLookup, "compact dawg does not contain prefixes of all words as terms");
+
+    t.assert(!compactDawg.lookup(""), "compact dawg does not contain the empty string as a term");
+    t.assert(compactDawg.lookupPrefix(""), "compact dawg does contain the empty string as a prefix");
+
+
+    t.end();
 });


### PR DESCRIPTION
Internal search code within dawg-cache was inconsistent as to whether chars were signed or unsigned, leading to inconsistent sort order between insertion and lookup. This PR standardizes on unsigned everywhere, casting to signed as required by specific external methods (e.g., on std::string).