### PR TITLE
[wip] consistify return values for compact dawg cache lookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ binding.Dawg.prototype.toCompactDawg = function(preserveCounts) {
 binding.CompactDawg.prototype.lookupPrefix = binding.CompactDawg.prototype._lookup;
 
 binding.CompactDawg.prototype.lookup = function(prefix) {
-    let out = this._lookup(prefix);
+    var out = this._lookup(prefix);
     return out && out.final ? out : null;
 }
 

--- a/index.js
+++ b/index.js
@@ -33,31 +33,11 @@ binding.Dawg.prototype.toCompactDawg = function(preserveCounts) {
     return new binding.CompactDawg(validate(this.toCompactDawgBuffer(preserveCounts)));
 }
 
-binding.CompactDawg.prototype.lookupPrefix = function(prefix) {
-    return this._lookup(prefix) != 0;
-}
+binding.CompactDawg.prototype.lookupPrefix = binding.CompactDawg.prototype._lookup;
 
 binding.CompactDawg.prototype.lookup = function(prefix) {
-    var lookup = this._lookup(prefix);
-    return lookup == 2 || lookup[0] == 2;
-}
-
-binding.CompactDawg.prototype.lookupPrefixCounts = function(prefix) {
-    var result = this._lookup(prefix);
-    if (result != 0) {
-        return {found: true, index: result[1], suffixCount: result[2], text: result[3] ? result[3] : prefix};
-    } else {
-        return {found: false}
-    }
-}
-
-binding.CompactDawg.prototype.lookupCounts = function(prefix) {
-    var result = this._lookup(prefix);
-    if (result != 0 && result[0] == 2) {
-        return {found: true, index: result[1], suffixCount: result[2], text: result[3] ? result[3] : prefix};
-    } else {
-        return {found: false}
-    }
+    let out = this._lookup(prefix);
+    return out && out.final ? out : null;
 }
 
 binding.CompactDawg.prototype.iterator = function(prefix) {

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -669,8 +669,6 @@ class CompactDawg : public Nan::ObjectWrap {
         } else {
             info.GetReturnValue().Set(Nan::Null());
         }
-
-        return;
     }
 
     static NAN_METHOD(Iterator) {


### PR DESCRIPTION
The work in https://github.com/mapbox/dawg-cache/pull/17 introduced some ways of using the compact DAWG that required extra metadata to be returned from the `lookup` function beyond truth-y or false-y values. In the interests of expediency, the first pass changed the return type of that function only in situations that would require the new data to save time on refactoring consuming code that wasn't related to the change.

This left the function in a weird state, though, where sometimes truth-y or false-y values were used to determine success or failure, and other times success of failure was determined by checking a property on a returned object.

This PR makes everything consistent. If `lookup` finds an entry, it returns an object with metadata about what it found (including count information if the cache includes counts, or not otherwise). If it doesn't find anything, it returns `null`, so truth-iness and false-iness are still reliable ways of determining success or failure if the extra metadata is not needed. This also simplifies the JS wrapping code somewhat.